### PR TITLE
Fix move down logic

### DIFF
--- a/EventLogging/Form1.cs
+++ b/EventLogging/Form1.cs
@@ -42,12 +42,14 @@ namespace WindowsFormsApp4
 
         private void button4_Click(object sender, EventArgs e)
         {
-            if (listBox2.SelectedIndex < listBox2.Items.Count)
+            if (listBox2.SelectedIndex != -1 &&
+                listBox2.SelectedIndex < listBox2.Items.Count - 1)
             {
                 int index = listBox2.SelectedIndex;
-                String text = listBox2.SelectedItem.ToString();
-                listBox2.Items.RemoveAt(listBox2.SelectedIndex);
+                string text = listBox2.SelectedItem.ToString();
+                listBox2.Items.RemoveAt(index);
                 listBox2.Items.Insert(index + 1, text);
+                listBox2.SelectedIndex = index + 1;
             }
         }
 

--- a/EventLogging/WindowsFormsApp4.csproj
+++ b/EventLogging/WindowsFormsApp4.csproj
@@ -46,19 +46,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\..\Desktop\Form1.cs">
+    <Compile Include="Form1.cs">
       <SubType>Form</SubType>
-      <Link>Form1.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\Desktop\Form1.Designer.cs">
+    <Compile Include="Form1.Designer.cs">
       <DependentUpon>Form1.cs</DependentUpon>
-      <Link>Form1.Designer.cs</Link>
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <EmbeddedResource Include="..\..\..\Desktop\Form1.resx">
+    <EmbeddedResource Include="Form1.resx">
       <DependentUpon>Form1.cs</DependentUpon>
-      <Link>Form1.resx</Link>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>


### PR DESCRIPTION
## Summary
- fix logic for moving down items in the list
- reference project files directly instead of missing Desktop path

## Testing
- `dotnet build EventLogging/EventLogging.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68402ea08868833192be2d892775b791